### PR TITLE
Added .htaccess files for initial gen-docs

### DIFF
--- a/static/apacheds/gen-docs/.htaccess
+++ b/static/apacheds/gen-docs/.htaccess
@@ -1,0 +1,10 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect to the latest release
+RewriteRule ^latest$ https://nightlies.apache.org/directory/apacheds/2.0.0.AM26/ [QSA,L]
+RewriteRule ^latest/(.*)$ https://nightlies.apache.org/directory/apacheds/2.0.0.AM26/$1 [QSA,L]
+
+# Redirect everything else
+RewriteRule ^(.*)$ https://nightlies.apache.org/directory/apacheds/$1 [QSA,L]
+

--- a/static/api/gen-docs/.htaccess
+++ b/static/api/gen-docs/.htaccess
@@ -1,0 +1,13 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect to the latest releases
+RewriteRule ^latest$ https://nightlies.apache.org/directory/api/1.0.2/ [QSA,L]
+RewriteRule ^latest/(.*)$ https://nightlies.apache.org/directory/api/1.0.2/$1 [QSA,L]
+
+RewriteRule ^latest2$ https://nightlies.apache.org/directory/api/2.0.1/ [QSA,L]
+RewriteRule ^latest2/(.*)$ https://nightlies.apache.org/directory/api/2.0.1/$1 [QSA,L]
+
+# Redirect everything else
+RewriteRule ^(.*)$ https://nightlies.apache.org/directory/api/$1 [QSA,L]
+

--- a/static/fortress/gen-docs/.htaccess
+++ b/static/fortress/gen-docs/.htaccess
@@ -1,0 +1,10 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect to the latest release
+RewriteRule ^latest$ https://nightlies.apache.org/directory/fortress/2.0.5/ [QSA,L]
+RewriteRule ^latest/(.*)$ https://nightlies.apache.org/directory/fortress/2.0.5/$1 [QSA,L]
+
+# Redirect everything else
+RewriteRule ^(.*)$ https://nightlies.apache.org/directory/fortress/$1 [QSA,L]
+

--- a/static/mavibot/gen-docs/.htaccess
+++ b/static/mavibot/gen-docs/.htaccess
@@ -1,0 +1,10 @@
+Options +FollowSymLinks
+RewriteEngine On
+
+# Redirect to the latest release
+RewriteRule ^latest$ https://nightlies.apache.org/directory/mavibot/1.0.0-M8/ [QSA,L]
+RewriteRule ^latest/(.*)$ https://nightlies.apache.org/directory/mavibot/1.0.0-M8/$1 [QSA,L]
+
+# Redirect everything else
+RewriteRule ^(.*)$ https://nightlies.apache.org/directory/mavibot/$1 [QSA,L]
+


### PR DESCRIPTION
This adds redirects from gen-docs to nightlies.

I don't know how it handles RewriteRules to a subdomain, whether it redirects or just shows the page (the latter would be even better; so the user doesn't have to leave the `directory.apache.org` domain).

I noticed the documentation for `Studio` and/or `Scimple` wasn't uploaded to nightlies yet.

/cc @elecharny 