### PR TITLE
Extract head. Add charset utf8 meta attribute.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/green.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/server-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "green") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "home") }}

--- a/layouts/apacheds/baseof.html
+++ b/layouts/apacheds/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/green.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/server-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "green") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "apacheds") }}

--- a/layouts/api/baseof.html
+++ b/layouts/api/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/brown.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/api-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "brown") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "api") }}

--- a/layouts/fortress/baseof.html
+++ b/layouts/fortress/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/turquoise.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/fortress-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "turquoise") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "fortress") }}

--- a/layouts/kerby/baseof.html
+++ b/layouts/kerby/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/orange.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/api-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "orange") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "kerby") }}

--- a/layouts/mavibot/baseof.html
+++ b/layouts/mavibot/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/turquoise.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/mavibot-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "turquoise") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "mavibot") }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,9 @@
+<head>
+    <meta charset="utf-8">
+    <title>{{ .context.Title }} &mdash; Apache Directory</title>
+
+    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
+    <link href="/css/{{ .csscolor }}.css" rel="stylesheet" type="text/css"/>
+
+    <link rel="shortcut icon" href="/images/server-icon_16x16.png" />
+</head>

--- a/layouts/scimple/baseof.html
+++ b/layouts/scimple/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/brown.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/api-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "brown") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "scimple") }}

--- a/layouts/studio/baseof.html
+++ b/layouts/studio/baseof.html
@@ -16,14 +16,7 @@
     limitations under the License.
 -->
 <html lang="en">
-<head>
-    <title>{{ .Title }} &mdash; Apache Directory</title>
-
-    <link href="/css/common.css" rel="stylesheet" type="text/css"/>
-    <link href="/css/blue.css" rel="stylesheet" type="text/css"/>
-
-    <link rel="shortcut icon" href="/images/studio-icon_16x16.png">
-</head>
+{{ partial "head.html" (dict "context" . "csscolor" "blue") }}
 <body>
 <div id="container">
     {{ partial "header.html" (dict "context" . "project" "studio") }}

--- a/source/apacheds/basic-ug/1.2-some-background.md
+++ b/source/apacheds/basic-ug/1.2-some-background.md
@@ -90,7 +90,7 @@ ISBN: 978-3-939084-07-5 <br/>
 
 #### Blogs
 
-* [cn=Directory Manager - All about Directory Server](http://blogs.sun.com/roller/page/DirectoryManager), Sun Blog
+* [dc=nawilson,dc=com - LDAP, programming, security, movies, and other stuff](https://nawilson.com/), Neil Wilson Blog
 
 #### Articles and other online resources
 

--- a/source/apacheds/basic-ug/4.1-mozilla-thunderbird.md
+++ b/source/apacheds/basic-ug/4.1-mozilla-thunderbird.md
@@ -79,4 +79,4 @@ You probably have noticed that the input fields in the two tabbed panes correspo
 ## Resources
 
  * [An introduction to Thunderbird](http://opensourcearticles.com/articles/introduction_to_thunderbird), Open Source Articles
- * [LDAP Attribute Mapping](http://www.mozilla.org/projects/thunderbird/specs/ldap.html) for Mozilla Thunderbird
+ * [LDAP Attribute Mapping](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/LDAP_Support) for Mozilla Thunderbird

--- a/source/api/user-guide.md
+++ b/source/api/user-guide.md
@@ -11,7 +11,7 @@ Pages with a (...) at the end of the title are not yet completed.
 Other pages are finished (but may be reviewed).
 </DIV>
 
-This document is about the LDAP API, developed at the Apache Software Foundation. It's a replacement for outdated Java/LDAP libraries like ([jLdap](http://www.openldap.org/jldap/), [Mozilla LDAP SDK](http://www.mozilla.org/directory/) and [JNDI](http://www.oracle.com/technetwork/java/jndi/index.html)).
+This document is about the LDAP API, developed at the Apache Software Foundation. It's a replacement for outdated Java/LDAP libraries like ([jLdap](http://www.openldap.org/jldap/), [Mozilla LDAP SDK](https://wiki.mozilla.org/Mozilla_LDAP_SDK_Programmer%27s_Guide/Getting_Started_With_LDAP_Java_SDK) and [JNDI](http://www.oracle.com/technetwork/java/jndi/index.html)).
 
 ## About this guide
 

--- a/source/studio/changelog.md
+++ b/source/studio/changelog.md
@@ -4,6 +4,58 @@ title: ChangeLog
 
 # ChangeLog
 
+## Apache Directory Studio Version 2.0.0-M15 (April 19th 2020)
+### Bugs
+
+* [DIRSTUDIO-1160](https://issues.apache.org/jira/browse/DIRSTUDIO-1160) - Attributes silently dropped and not imported when import LDIF and provider is Apache Directory LDAP API
+* [DIRSTUDIO-1194](https://issues.apache.org/jira/browse/DIRSTUDIO-1194) - build looks outside of repo (extra "..")
+* [DIRSTUDIO-1195](https://issues.apache.org/jira/browse/DIRSTUDIO-1195) - LDIF editor, entry editor, search result edtor fail to open with ClassCastException
+* [DIRSTUDIO-1197](https://issues.apache.org/jira/browse/DIRSTUDIO-1197) - Connection Network check fails when using the LDAP API
+* [DIRSTUDIO-1199](https://issues.apache.org/jira/browse/DIRSTUDIO-1199) - 2.0.0-M14 doesn't display objectGUID / objectSid correctly
+* [DIRSTUDIO-1200](https://issues.apache.org/jira/browse/DIRSTUDIO-1200)(https://issues.apache.org/jira/browse/DIRSTUDIO- - LDIF export fails with "Comparison method violates its general contract!"
+* [DIRSTUDIO-1202](https://issues.apache.org/jira/browse/DIRSTUDIO-1202) - Eclipse - No perspective to switch to.
+* [DIRSTUDIO-1203](https://issues.apache.org/jira/browse/DIRSTUDIO-1203) - testConnectFailures fails
+* [DIRSTUDIO-1204](https://issues.apache.org/jira/browse/DIRSTUDIO-1204) - ImageDialog can't read binary data
+* [DIRSTUDIO-1205](https://issues.apache.org/jira/browse/DIRSTUDIO-1205) - Which platforms does Studio work with TLS?
+* [DIRSTUDIO-1210](https://issues.apache.org/jira/browse/DIRSTUDIO-1210) - mixed up documentation bug, in replication section of studio docs
+* [DIRSTUDIO-1211](https://issues.apache.org/jira/browse/DIRSTUDIO-1211) - UserCertificate attribute shown as Invalid Certificate if "Apache... Client API" is used
+* [DIRSTUDIO-1215](https://issues.apache.org/jira/browse/DIRSTUDIO-1215) - Getting invalid certificate for binary certificate field
+* [DIRSTUDIO-1217](https://issues.apache.org/jira/browse/DIRSTUDIO-1217) - Viewing entries broken with newer Eclipse versions
+* [DIRSTUDIO-1231](https://issues.apache.org/jira/browse/DIRSTUDIO-1231) - linux eclipse swt ClassCastException LDAPBrowser TableEditor
+* [DIRSTUDIO-1233](https://issues.apache.org/jira/browse/DIRSTUDIO-1233) - NullPointerException within class EntryEditor.java
+* [DIRSTUDIO-1234](https://issues.apache.org/jira/browse/DIRSTUDIO-1234) - Image Editor (still) does not work correctly
+* [DIRSTUDIO-1240](https://issues.apache.org/jira/browse/DIRSTUDIO-1240) - Directory Studio displays "Invalid Certificate" after userCertificate upload
+* [DIRSTUDIO-1243](https://issues.apache.org/jira/browse/DIRSTUDIO-1243) - Certificate Parsing Fails under Java 11
+* [DIRSTUDIO-1246](https://issues.apache.org/jira/browse/DIRSTUDIO-1246) - Attribute export is different in version M13 and M14
+* [DIRSTUDIO-1247](https://issues.apache.org/jira/browse/DIRSTUDIO-1247) - Fix high memory usage in clipboard code
+* [DIRSTUDIO-1249](https://issues.apache.org/jira/browse/DIRSTUDIO-1249) - UTF-8 encoding problem
+
+### New Features
+
+* [DIRSTUDIO-648](https://issues.apache.org/jira/browse/DIRSTUDIO-648) - Studio should support the Password Modify Extended Operation according to RFC 3062
+
+### Improvements
+
+* [DIRSTUDIO-1124](https://issues.apache.org/jira/browse/DIRSTUDIO-1124) - Fix the user guide that still show how to configure ApacheDS 1.5.x...
+* [DIRSTUDIO-1150](https://issues.apache.org/jira/browse/DIRSTUDIO-1150) - Add a configation option for the connection timeout
+* [DIRSTUDIO-1207](https://issues.apache.org/jira/browse/DIRSTUDIO-1207) - Remove JNDI provider and JNDI layer
+* [DIRSTUDIO-1213](https://issues.apache.org/jira/browse/DIRSTUDIO-1213) - Support OSX Dark Mode
+* [DIRSTUDIO-1236](https://issues.apache.org/jira/browse/DIRSTUDIO-1236) - directory.apache.org refers to outdated "Mac OS X", which is now "macOS"
+
+### Tasks
+
+* [DIRSTUDIO-1222](https://issues.apache.org/jira/browse/DIRSTUDIO-1222) - Update to Eclipse 2020-03
+
+### Questions
+
+* [DIRSTUDIO-1165](https://issues.apache.org/jira/browse/DIRSTUDIO-1165) - Table Entry Editor - missing options following documentation
+* [DIRSTUDIO-1201](https://issues.apache.org/jira/browse/DIRSTUDIO-1201) - How does checking the "read-only" flag change the connection/authentication bind?
+
+### Outages
+
+* [DIRSTUDIO-1227](https://issues.apache.org/jira/browse/DIRSTUDIO-1227) - mvn clean install command throwing NPE
+
+
 ## Apache Directory Studio Version 2.0.0-M14 (September 8th 2018)
 
 * [DIRSTUDIO-987](https://issues.apache.org/jira/browse/DIRSTUDIO-987)  - strange behaviour with multi-valued RDN

--- a/source/studio/news.md
+++ b/source/studio/news.md
@@ -4,6 +4,17 @@ title: News
 
 # News
 
+<h2 class="news">Apache Directory Studio 2.0-0-M15 released <em>posted on April 19th, 2020</em></h2>
+
+The Apache Directory Team is pleased to announce the release of Apache
+Directory Studio 2.0.0-M15, the next milestone release of the version 2.0 of its Eclipse based LDAP Browser and Directory client. 
+
+You can download Apache Directory Studio 2.0.0-M14 as a standalone RCP application for Mac OS X, Linux and Windows here: <https://directory.apache.org/studio/downloads.html>
+
+You can also install it directly in Eclipse using this update site: <https://directory.apache.org/studio/update/>
+
+The full release notes can be found here: <https://directory.apache.org/studio/changelog.html>
+
 <h2 class="news">Apache Directory Studio 2.0-0-M14 released <em>posted on September 8th, 2018</em></h2>
 
 The Apache Directory Team is pleased to announce the release of Apache Directory Studio 2.0.0-M14, the next milestone release of the version 2.0 of its Eclipse based LDAP Browser and Directory client. 


### PR DESCRIPTION
Fixes broken encoding, e.g. `LÃ©charny`