### PR TITLE
Removed <center> tags to not mix markdown & html

### DIFF
--- a/source/studio/installation-in-eclipse.md
+++ b/source/studio/installation-in-eclipse.md
@@ -10,7 +10,7 @@ title: Installing Apache Directory Studio in Eclipse
 
 From workbench menu choose **Help > Install New Software...**.
 
-<center>![Help -> Install New Software...](installation-in-eclipse.data/1-menu.png)</center>
+![Help -> Install New Software...](installation-in-eclipse.data/1-menu.png)
 
 In the opened wizard input `https://directory.apache.org/studio/update` into the **Work with:** text field and press **Enter**.
 
@@ -19,57 +19,57 @@ After a while the table below will show the available categories.
 
 Choose **Apache Directory Studio**. You don't need to choose **Apache Directory Studio Dependencies**, the required dependencies will be automatically installed if required. Click **Next**.
 
-<center>![Available Software](installation-in-eclipse.data/2-available-software.png)</center>
+![Available Software](installation-in-eclipse.data/2-available-software.png)
 
 Review the installation details and click **Next**.
 
-<center>![Install Details](installation-in-eclipse.data/3-install-details.png)</center>
+![Install Details](installation-in-eclipse.data/3-install-details.png)
 
 Accept the license agreement, Apache Directory Studio is licensed under the Apache License, Version 2.0. Click **Finish**.
 
-<center>![Review Licenses](installation-in-eclipse.data/4-review-licenses.png)</center>
+![Review Licenses](installation-in-eclipse.data/4-review-licenses.png)
 
 Apache Directory Studio plugins are not signed yet, so you have to agree to the warning.
 
-<center>![Warning](installation-in-eclipse.data/5-warning.png)</center>
+![Warning](installation-in-eclipse.data/5-warning.png)
 
 You also have to trust the JCE Code Signing CA.
 
-<center>![Certificates](installation-in-eclipse.data/6-certificates.png)</center>
+![Certificates](installation-in-eclipse.data/6-certificates.png)
 
 After installation it is recommended to restart Eclipse.
 
 <!--
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_1.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_1.png)
 
 Next, please specify the Apache Directory Studio update site. Click the **New Remote Site...** button. In the dialog input the following and press **OK**:
 
 Name: **Apache Directory Studio Update Site**
 URL: **[https://directory.apache.org/studio/update](https://directory.apache.org/studio/update)**
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_2.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_2.png)
 
 Make sure the new update site is checked an press **Finish**.
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_3.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_3.png)
 
 Now the install manager checks the update site and presents the search results. Select the feature you want to install and click **Next**.
 In our example, we have selected the LDAP Browser.
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_4.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_4.png)
 
 Accept the license agreement, the Apache Directory Studio Browser is distributed under the Apache License, Version 2.0 and click **Next**.
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_5.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_5.png)
 
 In the next dialog ensure that the Apache Directory Studio features you have choosen are selected (here the LDAP Browser) and click to **Finish**.
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_6.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_6.png)
 
 Now the install manager loads the necessary files. When download is finished you have to verify the installation, please click to **Install**.
 
-<center>![Download](installation-in-eclipse.data/gettingstarted_install_7.png)</center>
+![Download](installation-in-eclipse.data/gettingstarted_install_7.png)
 
 After installation it is recommended to restart the Eclipse workbench.
 


### PR DESCRIPTION
This because the [current page](https://directory.apache.org/studio/installation-in-eclipse.html) does not show images otherwise

Before:

![image](https://user-images.githubusercontent.com/10008950/109422559-5de53300-79dc-11eb-9f21-c2ca22339ebe.png)

After:

![image](https://user-images.githubusercontent.com/10008950/109422570-69385e80-79dc-11eb-946c-55e56b61d25d.png)