### PR TITLE
Updated styling for the 'reporting bugs' page of ApacheDS

### DIFF
--- a/source/apacheds/advanced-ug/0.1-reporting-bugs.md
+++ b/source/apacheds/advanced-ug/0.1-reporting-bugs.md
@@ -20,7 +20,7 @@ We've created a simple archetype for you to rapidly create a Maven project that 
 
 So you can write client code in your test case immediately. Just add your code, tar gzip the project, and attach it to your JIRA issue on the ApacheDS JIRA here:
 
- [https://issues.apache.org/jira/browse/DIRSERVER]
+[https://issues.apache.org/jira/browse/DIRSERVER](https://issues.apache.org/jira/browse/DIRSERVER)
 
 We'll prioritize your bug higher than others and probably fix it rapidly because the problem is isolated thanks to your testcase submission. We will in fact strip out your testcase and add it to our suite of test cases to make sure ApacheDS always passes this integration test you've provided.
 
@@ -28,47 +28,52 @@ We'll prioritize your bug higher than others and probably fix it rapidly because
 
 To use the archetype you'll need to check it out and install it. Here's how you can do that for the leading edge of 2.0.0:
 
-
-	svn co http://svn.apache.org/repos/asf/directory/documentation/samples/trunk/apacheds-archetype-testcase
-	cd apacheds-archetype-testcase
-	mvn install
+```bash
+svn co http://svn.apache.org/repos/asf/directory/documentation/samples/trunk/apacheds-archetype-testcase
+cd apacheds-archetype-testcase
+mvn install
+```
 
 This will install the archetype onto your local repository. Now you can invoke the archetype.
 
-h3. Invoking (running) the archetype: generating the testcase project
+### Invoking (running) the archetype: generating the testcase project
 
 Once you checkout the archetype plugin and install it you can use it like so to generate a foo-test project:
-{noformat}
+
+```bash
 mvn archetype:generate -DarchetypeGroupId=org.apache.directory.samples \
                        -DarchetypeArtifactId=apacheds-archetype-testcase \
                        -DarchetypeVersion=1.5.5-SNAPSHOT \
                        -DgroupId=com.acme -DartifactId=foo-test -Dpackage=com.acme
-{noformat}
+```
+
 This will generate the default test case project with the following tree structure:
-{noformat}
+
+```bash
 ~/foo-test$ tree
 .
 |-- pom.xml
-`-- src
+|-- src
     |-- main
-    |   `-- java
-    |       `-- com
-    |           `-- acme
-    |               `-- Dummy.java
-    `-- test
+    |   |-- java
+    |       |-- com
+    |           |-- acme
+    |               |-- Dummy.java
+    |-- test
         |-- java
-        |   `-- com
-        |       `-- acme
+        |    -- com
+        |        -- acme
         |           |-- AdvancedTest.java
         |           |-- AdvancedTestApacheDsFactory.java
-        |           `-- MinimalTest.java
-        `-- resources
+        |           |-- MinimalTest.java
+        |-- resources
             |-- log4j.properties
             |-- sevenSeas_data.ldif
-            `-- sevenSeas_schema.ldif
+            |-- sevenSeas_schema.ldif
 
 10 directories, 8 files
-{noformat}
+```
+
 * Dummy.java - this is just a placeholder file to make sure that Maven works properly.
 * MinimalTest - a minimal ApacheDS Integration Test. It contains two test methods to demonstrate usage of JNDI and the ApacheDS core API. Add your own test method here.
 * AdvancedTest - an advanced ApacheDS Integration Test in case you need a special configuration for your test. It demonstrates how to add a new partition, how to enable LDAPS, how to enable a disabled schema, how to inject a custom schema, and how to inject custom test data.
@@ -79,37 +84,38 @@ This will generate the default test case project with the following tree structu
 * sevenSeas_schema.ldif - sample custom schema used by the advanced test.
 
 Once you do this you can cd into foo-test and just build and test it for fun to see what happens.  This will build, and test the sample test cases (they should pass) that comes packaged with the project you just created. CD into foo-test and run the following command:
-{noformat}
+
+```bash
 mvn test
-{noformat}
+```
+
 Now you can customize the MinimalTest.java or AdvancedTest.java file to isolate your bug. Open the classes with your favorite editor and goto town.  However if you want to pull this project into your IDE and edit it there you can use Maven's IDEA, Eclipse and Netbeans integration to create IDE project descriptors for them.  Then you can import this project into your IDE.  Here's how:
 
-h4. For IDEA
+#### For IDEA
 
-{noformat}
+```bash
 mvn idea:idea
-{noformat}
+```
 
-h4. For Eclipse
+#### For Eclipse
 
-{noformat}
+```bash
 mvn eclipse:eclipse
-{noformat}
+```
 
-h4. For Netbeans
+#### For Netbeans
 
-See this page: [http://maven.apache.org/guides/mini/guide-ide-netbeans/guide-ide-netbeans.html].
+See this page: [http://maven.apache.org/guides/mini/guide-ide-netbeans/guide-ide-netbeans.html](http://maven.apache.org/guides/mini/guide-ide-netbeans/guide-ide-netbeans.html).
 
-h3. Note about version
+### Note about version
 
 Note that this archetype is specific for ApacheDS 1.5.5.
 
-h2. Why a Maven Archetype for Testing?
+## Why a Maven Archetype for Testing?
 
-# Easy and fast to start integration testing ApacheDS.
-# We (developers of ApacheDS) can use it ourselves.
-# We want users of ApacheDS to help us help them.
-# Users need to customize a project with perhaps additional dependencies.
-# Users can add many test cases to the project.
-# Tests isolating custom bugs can be incorporated into our community test suite for ApacheDS.
-
+* Easy and fast to start integration testing ApacheDS.
+* We (developers of ApacheDS) can use it ourselves.
+* We want users of ApacheDS to help us help them.
+* Users need to customize a project with perhaps additional dependencies.
+* Users can add many test cases to the project.
+* Tests isolating custom bugs can be incorporated into our community test suite for ApacheDS.


### PR DESCRIPTION
This fixes the styling for the reporting bugs page.

See the current page here: https://directory.apache.org/apacheds/advanced-ug/0.1-reporting-bugs.html