### PR TITLE
Make the left portion of the site header clickable

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,5 @@
 <div id="header">
+    <a href="/"><div id="headerClick"></div></a>
     <div id="subProjectsNavBar">
         <a href="/">
             {{ if eq .project "home" }}

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -101,6 +101,15 @@ h6
 	background-repeat: no-repeat;
 }
 
+#headerClick
+{
+	width: 500px;
+	height: 152px;
+	position: absolute;
+	margin-top: 10px;
+	margin-left: 10px;
+}
+
 #subProjectsNavBar 
 {
 	color: white;


### PR DESCRIPTION
The header image is a full width background image, the whole thing is not clickable, but the portion with the directory logo is.
